### PR TITLE
unpacking will fail if file already exists

### DIFF
--- a/modules/trayservice.jsm
+++ b/modules/trayservice.jsm
@@ -85,8 +85,9 @@ const _directory = (function() {
         if (length != 0 && entryPath[length-1] != "") {
             // Forge full path for extracted file, and extract it
             fullPath.append(entryPath[length-1]);
-            console.log("lib full path", fullPath);
-            zipReader.extract(entryName, fullPath);
+            if (!fullPath.exists()) {
+                zipReader.extract(entryName, fullPath);
+            }
         }
     }
     zipReader.close();


### PR DESCRIPTION
Unpacking will fail if file already exists. Tested on Windows.

Steps to reproduce:
1. install extension - unpacking will happen, everything works
2. close thunderbird
3. open thunderbird again
4. extension will trigger unpacking again, will try to overwrite existing files and this will fail, unpacked files are ready-only, so access is denied, extension crashes

Solution - skip existing files when unpacking. 

Files will not change. So overwriting is not necessary. Also this saves some IO overhead and time on startup.